### PR TITLE
1 fix running tests on static scaffolding gives errors

### DIFF
--- a/bricks/scaffolding_test/CHANGELOG.md
+++ b/bricks/scaffolding_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.3
+
+- Fix for unit testing bug with more than 4 properties or names that push the UI beyond 800x600
+
 # 0.0.2
 
 - Now part of brickhub.dev - so can simplify install

--- a/bricks/scaffolding_test/__brick__/test/features/{{feature}}/presentation/views/{{feature}}_edit_view_test.dart
+++ b/bricks/scaffolding_test/__brick__/test/features/{{feature}}/presentation/views/{{feature}}_edit_view_test.dart
@@ -79,7 +79,10 @@ void main() {
       when(() => mock{{feature.pascalCase()}}EditBloc.state).thenReturn(const {{feature.pascalCase()}}EditState({{#properties}}{{name}}:{{{testValue}}}, {{/properties}}));
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byKey({{feature.pascalCase()}}EditView.topLeftButtonKey));
+      final testFinder = find.byKey({{feature.pascalCase()}}EditView.topLeftButtonKey);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+
       await tester.pumpWidget(widget);
 
       verify(() => mockNavigatorObserver.didPop(any(), any())).called(1);
@@ -116,7 +119,11 @@ void main() {
       final addEvent = {{feature.pascalCase()}}EditEventSubmitted();
 
       when(() => mock{{feature.pascalCase()}}EditBloc.add(addEvent)).thenAnswer((_) async {}); 
-      await tester.tap(find.byKey({{feature.pascalCase()}}EditView.bottomRightButtonKey));
+
+      final testFinder = find.byKey({{feature.pascalCase()}}EditView.bottomRightButtonKey);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+
       await tester.pumpWidget(widget);
 
       verify(() => mock{{feature.pascalCase()}}EditBloc.add(addEvent)).called(1);
@@ -137,7 +144,11 @@ void main() {
       final deleteEvent = {{feature.pascalCase()}}EditEventDelete();
 
       when(() => mock{{feature.pascalCase()}}EditBloc.add(deleteEvent)).thenAnswer((_) async {}); 
-      await tester.tap(find.byKey({{feature.pascalCase()}}EditView.bottomLeftButtonKey));
+
+      final testFinder = find.byKey({{feature.pascalCase()}}EditView.bottomLeftButtonKey);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+      
       await tester.pumpWidget(widget);
 
       verify(() => mock{{feature.pascalCase()}}EditBloc.add(deleteEvent)).called(1);
@@ -192,7 +203,10 @@ void main() {
       when(() => mock{{feature.pascalCase()}}EditBloc.add(event)).thenAnswer((invocation) {});
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byKey(const Key('edit-{{name}}-field')));
+      final testFinder = find.byKey(const Key('edit-{{name}}-field'));
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+      
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpWidget(widget);
 

--- a/bricks/scaffolding_test/__brick__/test/features/{{feature}}/presentation/views/{{feature}}_read_view_test.dart
+++ b/bricks/scaffolding_test/__brick__/test/features/{{feature}}/presentation/views/{{feature}}_read_view_test.dart
@@ -92,7 +92,9 @@ void main() {
           .thenReturn({{feature.pascalCase()}}ReadStateLoading());
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byKey(testKey));
+      final testFinder = find.byKey(testKey);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
       await tester.pumpWidget(widget);
 
       final captured =
@@ -163,7 +165,10 @@ void main() {
       when(() => mock{{feature.pascalCase()}}ReadBloc.state).thenReturn({{feature.pascalCase()}}ReadStateLoading());
 
       await tester.pumpWidget(makeTestableWidget({{feature.pascalCase()}}ReadView(bloc: mock{{feature.pascalCase()}}ReadBloc)));
-      await tester.tap(find.byIcon(Icons.refresh));
+
+      final testFinder = find.byIcon(Icons.refresh);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
       await tester.pump();
 
       verify(() => mock{{feature.pascalCase()}}ReadBloc.add(const {{feature.pascalCase()}}ReadEventReload())).called(1);
@@ -229,7 +234,10 @@ void main() {
       when(() => mock{{feature.pascalCase()}}ReadBloc.state).thenReturn({{feature.pascalCase()}}ReadStateLoading());
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byKey({{feature.pascalCase()}}ReadView.topLeftButtonKey));
+      final testFinder = find.byKey({{feature.pascalCase()}}ReadView.topLeftButtonKey);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+      
       await tester.pumpWidget(widget);
 
       verify(() => mockNavigatorObserver.didPop(any(), any())).called(1);
@@ -241,7 +249,10 @@ void main() {
       when(() => mock{{feature.pascalCase()}}ReadBloc.state).thenReturn({{feature.pascalCase()}}ReadStateLoading());
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byKey({{feature.pascalCase()}}ReadView.bottomRightButtonKey));
+      final testFinder = find.byKey({{feature.pascalCase()}}ReadView.bottomRightButtonKey);
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+      
       await tester.pumpWidget(widget);
 
       final captured =
@@ -265,7 +276,10 @@ void main() {
           {{feature.pascalCase()}}ReadStateSuccess({{feature}}s: test{{feature.pascalCase()}}s, totalCount: 1));
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byKey(ObjectKey(test{{feature.pascalCase()}})));
+      final testFinder = find.byKey(ObjectKey(test{{feature.pascalCase()}}));
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+
       await tester.pumpWidget(widget);
 
       final captured =
@@ -289,8 +303,10 @@ void main() {
           {{feature.pascalCase()}}ReadStateSuccess({{feature}}s: test{{feature.pascalCase()}}s, totalCount: 1));
       await tester.pumpWidget(widget);
 
-      await tester
-          .tap(find.byKey({{feature.pascalCase()}}ReadView.deleteButtonKey(test{{feature.pascalCase()}}.id)));
+      final testFinder = find.byKey({{feature.pascalCase()}}ReadView.deleteButtonKey(test{{feature.pascalCase()}}.id));
+      await tester.ensureVisible(testFinder);
+      await tester.tap(testFinder);
+      
       await tester.pumpWidget(widget);
 
       final captured =

--- a/bricks/scaffolding_test/brick.yaml
+++ b/bricks/scaffolding_test/brick.yaml
@@ -1,6 +1,6 @@
 name: scaffolding_test
 description: Unit tests for scaffolding a flutter app with bloc, data/domain/presentation
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/sjhorn/mason_bricks/tree/main/bricks/scaffolding_test
 
 environment:


### PR DESCRIPTION
## Brick

<!--- Put an `x` in all the boxes that apply: -->
- [x] scaffolding_test

## Status

READY

## Breaking Changes

NO

## Description

Fix the unit tests to ensure the buttons / inkwell are in view when clicking

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore